### PR TITLE
cache handler now gets clean field metadata

### DIFF
--- a/lib/redis-cache-handler.js
+++ b/lib/redis-cache-handler.js
@@ -78,8 +78,8 @@ function cachedHandler(handler, options) {
         };
 
         const invokeHandler = function () {
-            // attach result listener to cache metadata and attach
-            query.post(cacheResult);
+            // attach result listener to cache pristine metadata and attach
+            query.postHandlers.unshift(cacheResult);
             handler(query, reply);
         };
 


### PR DESCRIPTION
cache handler now gets clean field metadata related to only the query results. result metadata written immediately after query handler and before any registered post handlers