### PR TITLE
I5-2185

### DIFF
--- a/lib/redis-cache-handler.js
+++ b/lib/redis-cache-handler.js
@@ -27,11 +27,13 @@ class RedisReadStream extends stream.Readable {
 
     _read () {
         var self = this;
-        this.client.hget(this.key, ['record', this.index++].join(':'), function (err, result) {
-            if (err) return this.emit('error', err);
 
-            result ?
-                self.push(_.mapValues(JSON.parse(result), v => {
+        this.client.hmget([this.key, 'count', ['record', this.index++].join(':')], function (err, results) {
+            if(err) return this.emit('error', err);
+
+            if(self.index > results[0]) self.push(null);
+            else results[1] ?
+                self.push(_.mapValues(JSON.parse(results[1]), v => {
                     return ISO_8601_FULL.test(v) ? new Date(v) : v;
                 }))
                 :


### PR DESCRIPTION
Only returns 'new' records from cache.  If a query sample returns less records than the previous sample, cache now only returns those records, rather than the new records and non-overwritten records from previous query.