### PR TITLE
error handlers & 'queryError' event

### DIFF
--- a/lib/query-builder.js
+++ b/lib/query-builder.js
@@ -39,6 +39,7 @@ class QueryBuilder {
             preHandlers: [],
             postHandlers: [],
             throughHandlers: [],
+            errorHandlers: [],
             plugins: [],
             listeners: []
         };
@@ -216,6 +217,16 @@ class QueryBuilder {
      */
     through(streams) {
         this.defn.throughHandlers = this.defn.throughHandlers.concat(streams);
+        return this;
+    }
+
+    /**
+     * Applies an error interceptor
+     * @param interceptor
+     * @return {QueryBuilder}
+     */
+    error(interceptor) {
+        this.defn.errorHandlers = this.defn.errorHandlers.concat(interceptor);
         return this;
     }
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -13,7 +13,8 @@ var $ = require('highland');
 const SCHEMA = joi.object({
     preHandlers: joi.array().items(joi.func()).default([]),
     postHandlers: joi.array().items(joi.func()).default([]),
-    throughHandlers: joi.array().items(joi.alternatives([ joi.func(), joi.object().type(Stream) ])).default([]),
+    throughHandlers: joi.array().items(joi.alternatives([joi.func(), joi.object().type(Stream)])).default([]),
+    errorHandlers: joi.array().items(joi.func()).default([]),
     handler: joi.func().required(),
     payload: joi.any(),
     user: joi.any(),
@@ -36,7 +37,7 @@ class Query extends EventEmitter {
 
         // properties declared here for jsdoc purposes
         this.limit = -1;
-        this.preHandlers = this.postHandlers = this.throughHandlers = [];
+        this.preHandlers = this.postHandlers = this.throughHandlers = this.errorHandlers = [];
         this.options = {};
         this.params = {};
     }
@@ -81,6 +82,16 @@ class Query extends EventEmitter {
      */
     post(handler) {
         this.postHandlers = this.postHandlers.concat(handler);
+        return this;
+    }
+
+    /**
+     * Adds an error handler
+     * @param handler
+     * @return {Query}
+     */
+    error (handler) {
+        this.errorHandlers = this.errorHandlers.concat(handler);
         return this;
     }
 
@@ -157,7 +168,7 @@ class Query extends EventEmitter {
     }
 
     /**
-     * Invokes the query's handler function and is responsible for initializing the result
+     * Invokes the query's handler function and is responsible for initializing the result.
      * @param {function(Query, function)} handler the handler function
      * @return {Promise.<QueryResult>}
      * @private
@@ -166,7 +177,7 @@ class Query extends EventEmitter {
         const self = this;
 
         // short circuit the handler if already cancelled
-        if (this.cancelled) return new QueryResult(this);
+        if (this.cancelled) return P.resolve(new QueryResult(this));
 
         return new P(function (resolve, reject) {
 
@@ -191,12 +202,29 @@ class Query extends EventEmitter {
         });
     }
 
-    _setResult(result) {
+    /**
+     * Emits a 'queryError' event, taps the collection of error
+     * handlers, then re-throws the error to propagate it up
+     * @param err
+     * @return {Promise.}
+     * @private
+     */
+    _handleError (err) {
+        this.emit('queryError', err);
+        return this._tapChain(this.errorHandlers)(err)
+            .finally(() => {
+                throw err;
+            });
+    }
+
+    _setResult (result) {
         this.result = result;
     }
 
     /**
-     * Runs the query with the supplied parameters, returning a promise to a QueryResult
+     * Runs the query with the supplied parameters, returning a promise to a QueryResult.
+     * An Error while invoking the handler causing a rejection will cause the collection of
+     * error handlers to be tapped before the error is re-thrown.
      * @param {*} params runtime query params
      * @return {Promise.<QueryResult>}
      */
@@ -210,7 +238,8 @@ class Query extends EventEmitter {
         return this._promise = P.bind(this)
             .tap(() => this.emit('execute'))
             .tap(() => this._tapChain(this.preHandlers)(this))
-            .then(() => this._invokeHandler(this.handler))
+            .then(() => this._invokeHandler(this.handler)
+                .catch(err => this._handleError(err)))
             .tap(r => this._setResult(r))
             .tap(r => this._tapChain(this.postHandlers)(r))
             .tap(r => this.emit('result', r));


### PR DESCRIPTION
added error handlers collection that is tapped and 'queryError' event that is emitted on a thrown or replied error/rejection during handler invocation