### PR TITLE
prevent holding onto old data when overwriting a cache key's entry

### DIFF
--- a/lib/redis-cache-handler.js
+++ b/lib/redis-cache-handler.js
@@ -71,6 +71,7 @@ function cachedHandler (handler, options) {
                 // put serializer at the front of the line
                 result.throughHandlers.unshift(s => s.pipe(new RedisWriteStream(client, key)));
                 const cmd = client.multi()
+                    .del(key)
                     .hset(key, 'selected', parseInt(result.selected))
                     .hset(key, 'fields', JSON.stringify(result.fields))
                     .hset(key, 'hash', signature);


### PR DESCRIPTION
cacheHandler now purges a cache key's hash prior to writing to it to prevent an entry overwrite to hold onto old record data if the new stream contains less records