### PR TITLE
handle all query execution errors same

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -208,14 +208,15 @@ class Query extends EventEmitter {
     }
 
     /**
-     * Emits a 'queryError' event, taps the collection of error
+     * Cancels this query, emits an 'error' event, taps the collection of error
      * handlers, then re-throws the error to propagate it up
      * @param err
      * @return {Promise.}
      * @private
      */
     _handleError (err) {
-        this.emit('queryError', err);
+        this.cancel();
+        this.emit('error', err);
         return this._tapChain(this.errorHandlers)(err)
             .finally(() => {
                 throw err;
@@ -243,10 +244,10 @@ class Query extends EventEmitter {
         return this._promise = P.bind(this)
             .tap(() => this.emit('execute'))
             .tap(() => this._tapChain(this.preHandlers)(this))
-            .then(() => this._invokeHandler(this.handler)
-                .catch(err => this._handleError(err)))
+            .then(() => this._invokeHandler(this.handler))
             .tap(r => this._setResult(r))
             .tap(r => this._tapChain(this.postHandlers)(r))
+            .catch(err => this._handleError(err))
             .tap(r => this.emit('result', r));
     }
 


### PR DESCRIPTION
- all errors during query execution are now handled the same way, not just handler errors
- handling query execution errors now implicitly cancels the query
- changed 'queryError' event to just 'error' for simplicity