### PR TITLE
queryResult.toArray error propagation & revert 'error' event back to 'queryError' when handling

### DIFF
--- a/lib/query-result.js
+++ b/lib/query-result.js
@@ -148,7 +148,7 @@ class QueryResult {
      * Returns a promise that resolves to an array of all data values
      */
     toArray() {
-        return new P(resolve => this.stream().toArray(resolve));
+        return new P((resolve, reject) => this.stream().stopOnError(err => reject(err)).toArray(resolve));
     }
 
     /**

--- a/lib/query.js
+++ b/lib/query.js
@@ -218,7 +218,7 @@ class Query extends EventEmitter {
         this.cancel();
         return this._tapChain(this.errorHandlers)(err)
             .finally(() => {
-                this.emit('error', err);
+                this.emit('queryError', err);
                 throw err;
             });
     }

--- a/test/query-spec.js
+++ b/test/query-spec.js
@@ -254,7 +254,7 @@ describe('QueryBuilder', function () {
             return query('select * fromwhere')
                 .handler(handler)
                 .build()
-                .on('error', spy)
+                .on('queryError', spy)
                 .execute()
                 .then(() => {
                     throw new Error('Should not succeed');
@@ -278,7 +278,7 @@ describe('QueryBuilder', function () {
             return query('select * fromwhere')
                 .handler((q, r) => r(error))
                 .build()
-                .on('error', spy)
+                .on('queryError', spy)
                 .execute()
                 .then(() => {
                     throw new Error('Should not succeed');


### PR DESCRIPTION
- fixed queryResult.toArray to properly stop the stream and reject when an error is encountered
- reverted change of event emitter by query in _handleErrors from 'error' back to 'queryError'
- reverted test change