### PR TITLE
I5-5301 - last queried at

### DIFF
--- a/lib/query-builder.js
+++ b/lib/query-builder.js
@@ -78,7 +78,7 @@ class QueryBuilder {
      * @return {QueryBuilder}
      */
     option(name, value) {
-        this.defn.options = _.set(this.defn.options, name, value);
+        this.defn.options = _.set(this.defn.options, [name], value);
         return this;
     }
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -201,11 +201,17 @@ class Query extends EventEmitter {
                 // give the handler a moment to configure field metadata before processing the results
                 setImmediate(() => resolve(qr));
 
+                // stamp replied-at
+                self.handlerCompletedAt = new Date();
+
                 // return the configuration shim
                 return qr.shim();
             });
 
             self.on('cancel', reply);
+
+            // stamp invoked-at
+            self.handlerInvokedAt = new Date();
             handler(self, reply);
         });
     }
@@ -230,6 +236,11 @@ class Query extends EventEmitter {
         this.result = result;
     }
 
+    param (name, value) {
+        this.params[name] = value;
+        return this;
+    }
+
     /**
      * Runs the query with the supplied parameters, returning a promise to a QueryResult.
      * An Error while invoking the handler causing a rejection will cause the collection of
@@ -246,10 +257,14 @@ class Query extends EventEmitter {
 
         return this._promise = P.bind(this)
             .tap(() => this.emit('execute'))
+            .tap(() => this.preInvokedAt = new Date())
             .tap(() => this._tapChain(this.preHandlers)(this))
+            .tap(() => this.preCompletedAt = new Date())
             .then(() => this._invokeHandler(this.handler))
             .tap(r => this._setResult(r))
+            .tap(() => this.postInvokedAt = new Date())
             .tap(r => this._tapChain(this.postHandlers)(r))
+            .tap(() => this.postCompletedAt = new Date())
             .catch(err => this._handleError(err))
             .tap(r => this.emit('result', r));
     }
@@ -278,6 +293,7 @@ class Query extends EventEmitter {
      */
     cancel () {
         this.cancelled = true;
+        this.cancelledAt = new Date();
         this.emit('cancel');
         if (this.result) this.result.cancel();
         return this;


### PR DESCRIPTION
- added various time stamps during query execution
- fixed querybuilder.option() to use _.set array notation just like query.option()

+feature - new api addition